### PR TITLE
Update to docker 18.09.6

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = nvidia-container-runtime
 	pkgdesc = NVIDIA container runtime
-	pkgver = 2.0.0+1.docker18.09.3
+	pkgver = 2.0.0+3.docker18.09.6
 	pkgrel = 1
 	url = https://github.com/NVIDIA/nvidia-container-runtime
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = nvidia-container-runtime
 	depends = libseccomp
 	depends = nvidia-container-runtime-hook
 	source = git+https://github.com/NVIDIA/nvidia-container-runtime.git#commit=03af0a80dbcbcfa09a828cde46151749bee2480e
-	source = git+https://github.com/opencontainers/runc.git#commit=6635b4f0c6af3810594d2770f662f34ddc15b40d
+	source = git+https://github.com/opencontainers/runc.git#commit=2b18fe1d885ee5083ef9f0838fee39b62d653e30
 	sha256sums = SKIP
 	sha256sums = SKIP
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,9 +3,10 @@
 
 pkgname=nvidia-container-runtime
 
-pkgver=2.0.0+1.docker18.09.3
+pkgver=2.0.0+3.docker18.09.6
 _runtime_commit='03af0a80dbcbcfa09a828cde46151749bee2480e'
-_runc_commit='6635b4f0c6af3810594d2770f662f34ddc15b40d'
+_runc_commit='2b18fe1d885ee5083ef9f0838fee39b62d653e30'
+_runc_patch_commit='6635b4f0c6af3810594d2770f662f34ddc15b40d'
 _runc_path='gopath/src/github.com/opencontainers/runc'
 
 pkgrel=1
@@ -24,7 +25,7 @@ sha256sums=('SKIP'
 
 prepare() {
   cd runc
-  git apply ${srcdir}/nvidia-container-runtime/runtime/runc/${_runc_commit}/*
+  git apply ${srcdir}/nvidia-container-runtime/runtime/runc/${_runc_patch_commit}/*
   mkdir -p ${srcdir}/gopath/src/github.com/opencontainers
   ln -rTsf "${srcdir}/runc" "${srcdir}/${_runc_path}"
 }


### PR DESCRIPTION
@jshap70 The official binaries for Centos, Ubuntu... got updated with every new docker version. The current version is `18.09.6` (see kiendang/aur-nvidia-container-runtime-bin#2). However the [Makefile](https://github.com/NVIDIA/nvidia-container-runtime/blob/master/runtime/Makefile) only contains instructions for up to version `18.09.2`.

However the steps to build for a specific docker version can be inferred from the Makefile:
- Check out the same [`runc`](https://github.com/opencontainers/runc) commit that the docker version uses. For example, docker 18.09.1 use `runc@96ec2177ae841256168fcf76954f7177af9446eb`. Which docker version uses which `runc` commit can be see [here](https://github.com/docker/docker-ce/blob/v18.09.1/components/engine/hack/dockerfile/install/runc.installer).
- Apply a [patch](https://github.com/NVIDIA/nvidia-container-runtime/tree/master/runtime/runc) according to the `runc` commit.
- Build `runc` (`nvidia-container-docker` is just a patched `runc`)

It's just that I'm not entirely sure.